### PR TITLE
Tasks refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 .project
 .classpath
 .gradle
+.settings

--- a/README.txt
+++ b/README.txt
@@ -38,22 +38,19 @@ build:
    (:compileJava task depends on this task)
 
 :proguard
-   Process classes and JARs with ProGuard
-   -> :classes
+   Process classes and JARs with ProGuard (by default, this task is disabled,
+   more on this below)
+   -> :jar
 
-:androidPackageDebug
+:androidPackage
    Creates the Android application apk package, signed with debug key
+   or provided key (more on this below)
    -> :proguard
    (:assemble lifecycle task depends on this task)
 
-:androidPackageRelease
-   Creates the Android application apk package, which must be signed
-   before it is published
-   -> :proguard
-
 :androidInstall
-   Installs the debug package onto a running emulator or device
-   -> :androidPackageDebug
+   Installs the built package onto a running emulator or device
+   -> :assemble
 
 :androidUninstall
    Uninstalls the application from a running emulator or device
@@ -81,7 +78,7 @@ buildscript {
     mavenRepo(urls: 'http://jvoegele.com/maven2/')
   }
   dependencies {
-    classpath 'com.jvoegele.gradle.plugins:android-plugin:1.0'
+    classpath 'com.jvoegele.gradle.plugins:android-plugin:0.9.5'
   }
 }
 apply plugin: com.jvoegele.gradle.plugins.android.AndroidPlugin
@@ -129,15 +126,119 @@ environments.)
 Once you've performed these steps you can build your Android application
 by invoking the tasks described above.
 
+A complete minimal but real-world example is as follow.
+
+
+build.gradle
+============
+
+buildscript {
+  repositories {
+    mavenRepo(urls: 'http://jvoegele.com/maven2/')
+  }
+  dependencies {
+    classpath 'com.jvoegele.gradle.plugins:android-plugin:0.9.5'
+  }
+}
+apply plugin: com.jvoegele.gradle.plugins.android.AndroidPlugin
+repositories {
+    mavenCentral()
+}
+
+// Sets the package version
+version = "x.y.z"
+
+// Signing configuration, valid for all builds (1)
+androidPackage {
+	keyStore = "path/to/my/keystore"
+	keyAlias = "my-key-alias"
+	keyStorePassword = "mystorepass"
+	keyAliasPassword = "myaliaspass"
+}
+
+// Configure the filtering of resources with properties from the Gradle's project scope (2)
+processResources {
+	expand (project.properties)
+}
+
+// Configure a dedicated debug build (3)
+task configureDebug << {
+    jar.classifier = "debug"
+}
+
+// Configure a dedicated release build (4)
+task configureRelease << {
+    proguard.enabled = true
+}
+
+=============
+
+This build script configures the build to sign with a provided keystore. This configuration
+applays for every build (1).
+It also sets Gradle to expand properties in every resource file (2).
+
+In this way you can get a full build with the command:
+
+gradle assemble
+
+It processes all the resources, expanding them with properties from the project's scope, 
+compiles classes, packs them into the dex file, builds the apk, signs it with
+the provided keystore (but NOT proguards it) and zipaligns the package, which is named <project>-x.y.z.apk
+and placed in <project-root>/build/distributions.
+You can see the proguard task is skipped from Gradle's output during the build.
+
+You can create several build configurations and choose which one to execute from the
+gradle command line. 
+The task configureDebug (3) define the Gradle's classifier for the package name.
+Executing this build with the command:
+
+gradle configureDebug assemble
+
+create a package with same steps than the default build, but the package name
+is project-x.y.z-debug.apk.
+
+The task configureRelease (4) defines a release configuration task, which
+activate the proguarding step. Again, you get the package named <project>-x.y.z.apk
+in the same output directory.
+
+To disable signing and get a signed apk with the debug key, you can remove the
+androidPackage configuration (1): if keyStore or keyAlias are null, the signing is
+skipped and the debug key is used. Of course, you can put the signing configuration
+in a dedicated configuration task and invoke that task in order to get a signed
+package (or not to call it for the debug signed package).
+
+Also note that if you don't supply password (that is, keyStorePassword or keyAliasPassword
+are null), Gradle asks for them on the command line (not very good for CI servers...).
+
+
+To install the generated apk onto a running emulator or a device connected with USB (and
+configured in debug mode), run:
+
+gradle androidInstall
+
+This installs the default built package; as with previous examples, if you want to install the
+debug (or release) package, you have to issue:
+
+gradle configureDebug androidInstall
+
+or
+
+gradle configureRelease androidInstall
+ 
+
+The androidUninstall task unistalls the application from a running emulator or a device.
+There is no need to specify which package: there can be only one package to undeploy and
+it's defined by the base package name of the application, from androidManifest.xml.
+
 
 LIMITATIONS
 ===========
 
-In the current version of the Android plugin, the proguard task is
-incorporated into the build but is not very configurable.  It can be
-disabled, however, by setting "proguard.enabled = false" in your
-build.gradle file.
-
+* In the current version of the Android plugin, the proguard task is not very configurable.
+* Gingerbread SDK is not currently supported (it will be soon).
+* The androidManifest.xml file is not processed as a normal resource, i.e. there is
+  no properties expansion (so, for example, you don't get the version set in the version tag,
+  you have to align them manually).
 
 FUTURE DIRECTIONS
 =================

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,8 @@ dependencies {
 // Make sure all code is compiled, tested and checked before uploadArchives.
 uploadArchives.dependsOn ':build'
 
-// Facility to quicly clean Gradle's plugin cache
+
+// Facility to quickly clean Gradle's plugin cache (think01 devel)
 uploadArchives << {
 	delete ("C:/Documents and Settings/71727/.gradle/cache/com.jvoegele.gradle.plugins")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,6 @@ apply plugin: 'eclipse'
 version = '1.0-SNAPSHOT'
 group = 'com.jvoegele.gradle.plugins'
 
-outputPluginDir = "../clowai/tools/gradle-plugin"
-
 configurations {
     sshDeploy
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ apply plugin: 'eclipse'
 version = '1.0-SNAPSHOT'
 group = 'com.jvoegele.gradle.plugins'
 
+outputPluginDir = "../clowai/tools/gradle-plugin"
+
 configurations {
     sshDeploy
 }
@@ -34,8 +36,20 @@ dependencies {
 // Make sure all code is compiled, tested and checked before uploadArchives.
 uploadArchives.dependsOn ':build'
 
-
-// Facility to quickly clean Gradle's plugin cache (think01 devel)
-uploadArchives << {
-	delete ("C:/Documents and Settings/71727/.gradle/cache/com.jvoegele.gradle.plugins")
+// Task for building in Mousedog devel environment - to call before uploadArchives!
+task mousedogBuild << {
+	project.version = '1.0-mousedog'
+	outputPluginDir = "../clowai/tools/gradle-plugin"
+	
+	uploadArchives.repositories.mavenDeployer ({repository(url: "file:" + outputPluginDir)})
+	
+	uploadArchives.doLast {
+		// Facility to quickly clean Gradle's plugin cache (think01 devel)
+		println "Deleting Gradle's cache for updating plugin..."
+		// Home installation
+		delete ("/home/fabio/.gradle/cache/com.jvoegele.gradle.plugins")
+		// Office installation
+	//	delete ("C:/Documents and Settings/71727/.gradle/cache/com.jvoegele.gradle.plugins")
+		println "Cache deleted!"
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,3 +34,7 @@ dependencies {
 // Make sure all code is compiled, tested and checked before uploadArchives.
 uploadArchives.dependsOn ':build'
 
+// Facility to quicly clean Gradle's plugin cache
+uploadArchives << {
+	delete ("C:/Documents and Settings/71727/.gradle/cache/com.jvoegele.gradle.plugins")
+}

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -119,12 +119,12 @@ class AndroidPlugin implements Plugin<Project> {
 
   private void defineAndroidInstallTask() {
     androidInstallTask = project.task(ANDROID_INSTALL_TASK_NAME) << {
-      logger.info("Installing ${ant['out.debug.package']} onto default emulator or device...")
+      logger.info("Installing ${androidConvention.getApkArchivePath()} onto default emulator or device...")
       ant.exec(executable: ant['adb'], failonerror: true) {
         arg(line: ant['adb.device.arg'])
         arg(value: 'install')
         arg(value: '-r')
-        arg(path: ant['out.debug.package'])
+        arg(path: androidConvention.getApkArchivePath())
       }
     }
     androidInstallTask.description =

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -156,8 +156,8 @@ class AndroidPlugin implements Plugin<Project> {
   private void defineTaskDependencies() {
     project.tasks.compileJava.dependsOn(androidProcessResourcesTask)
     proguardTask.dependsOn(project.tasks.jar)
-    androidPackageTask.dependsOn(project.tasks.jar)
-    project.tasks.assemble.dependsOn(ANDROID_PACKAGE_TASK_NAME)
+    androidPackageTask.dependsOn(proguardTask)
+    project.tasks.assemble.dependsOn(androidPackageTask)
     androidInstallTask.dependsOn(project.tasks.assemble)
   }
 

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPluginConvention.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPluginConvention.groovy
@@ -10,8 +10,8 @@ class AndroidPluginConvention {
   File nativeLibsDir
   File androidManifest
   File intermediateDexFile
-  String apkBaseName
-  File apkArchivePath
+  private String apkBaseName
+  private File apkArchivePath
   
   AndroidPluginConvention(Project project) {
     this.project = project
@@ -25,11 +25,32 @@ class AndroidPluginConvention {
 	// Output paths
     genDir = new File(project.buildDir, 'gen')
     intermediateDexFile = new File(project.libsDir, "classes.dex")
+  }
+  
+  /**
+   * This value has to be calculated dinamically
+   * @return
+   */
+  public String getApkBaseName() {
     apkBaseName = project.jar.baseName 
-//        + (project.jar.appendix != null ? "-"+project.jar.appendix : "") 
-//        + (project.version != null ? "-"+project.version : "") 
-//        + (project.jar.classifier != null ? "-"+project.jar.classifier : "") 
-//        + ".apk"
-    apkArchivePath = new File (project.distsDir, apkBaseName + ".apk")
+    if (project.jar.appendix != null && project.jar.appendix.length() > 0) {
+      apkBaseName += "-"+project.jar.appendix
+    }
+    if (project.version != null && project.version.length() > 0) {
+      apkBaseName += "-"+project.version
+    }
+    if (project.jar.classifier != null && project.jar.classifier.length() > 0) {
+      apkBaseName += "-"+project.jar.classifier
+    }
+    return apkBaseName 
+  }
+  
+  /**
+   * This value has to be calculated dinamically
+   * @return
+   */
+  public File getApkArchivePath() {
+    apkArchivePath = new File (project.distsDir, getApkBaseName() + ".apk")
+    return apkArchivePath
   }
 }

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPluginConvention.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPluginConvention.groovy
@@ -10,14 +10,26 @@ class AndroidPluginConvention {
   File nativeLibsDir
   File androidManifest
   File intermediateDexFile
-
+  String apkBaseName
+  File apkArchivePath
+  
   AndroidPluginConvention(Project project) {
     this.project = project
+	
+	// Input paths
     resDir = new File(project.projectDir, 'res')
-    genDir = new File(project.buildDir, 'gen')
     assetsDir = new File(project.projectDir, 'assets')
     nativeLibsDir = new File(project.projectDir, 'libs')
     androidManifest = new File(project.projectDir, 'AndroidManifest.xml')
-    intermediateDexFile = new File(project.buildDir, "classes.dex")
+	
+	// Output paths
+    genDir = new File(project.buildDir, 'gen')
+    intermediateDexFile = new File(project.libsDir, "classes.dex")
+    apkBaseName = project.jar.baseName 
+//        + (project.jar.appendix != null ? "-"+project.jar.appendix : "") 
+//        + (project.version != null ? "-"+project.version : "") 
+//        + (project.jar.classifier != null ? "-"+project.jar.classifier : "") 
+//        + ".apk"
+    apkArchivePath = new File (project.distsDir, apkBaseName + ".apk")
   }
 }

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AaptExecTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AaptExecTask.groovy
@@ -17,7 +17,7 @@ class AaptExecTask extends AndroidAntTask {
                  resources: androidConvention.resDir.path,
                  assets: androidConvention.assetsDir,
                  androidjar: ant['android.jar'],
-                 outfolder: project.buildDir,
+                 outfolder: project.libsDir,
                  basename: project.name)
   }
 

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidAntTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidAntTask.groovy
@@ -1,10 +1,12 @@
 package com.jvoegele.gradle.tasks.android
 
+import com.jvoegele.gradle.plugins.android.AndroidPluginConvention 
+
 abstract class AndroidAntTask {
 
   protected final project
   protected final ant
-  protected final androidConvention
+  protected final AndroidPluginConvention androidConvention
 
   protected AndroidAntTask(project) {
     this.project = project

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
@@ -31,7 +31,7 @@ class AndroidPackageTask extends ConventionTask {
     ant = project.ant
     
     // Create necessary directories for this task
-    androidConvention.apkArchivePath.getParentFile().mkdirs()
+    androidConvention.getApkArchivePath().getParentFile().mkdirs()
   }
   
   @TaskAction
@@ -48,14 +48,14 @@ class AndroidPackageTask extends ConventionTask {
     }
     
     // Create temporary file for the zipaligning
-    File temp = new File (project.libsDir, androidConvention.apkBaseName + "-unaligned.apk")
-    ant.copy(file: androidConvention.apkArchivePath.toString(), toFile: temp.toString())
+    File temp = new File (project.libsDir, androidConvention.getApkBaseName() + "-unaligned.apk")
+    ant.copy(file: androidConvention.getApkArchivePath().toString(), toFile: temp.toString())
     // Do the alignment
-    zipAlign(temp, androidConvention.apkArchivePath)
+    zipAlign(temp, androidConvention.getApkArchivePath())
     // Remove temp file
     temp.delete()
     
-    logger.info("Final Package: " + androidConvention.apkArchivePath)
+    logger.info("Final Package: " + androidConvention.getApkArchivePath())
   }
   
   private void sign() {

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
@@ -1,0 +1,105 @@
+package com.jvoegele.gradle.tasks.android
+
+import com.jvoegele.gradle.plugins.android.AndroidPluginConvention 
+import com.jvoegele.gradle.tasks.android.AndroidSdkToolsFactory 
+import org.gradle.api.internal.ConventionTask;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * 
+ * @author think01
+ *
+ */
+class AndroidPackageTask extends ConventionTask {
+  
+  // Public configuration properties
+  public String keyStore
+  public String keyAlias
+  public String keyStorePassword
+  public String keyAliasPassword
+  public boolean verbose
+
+  // Internal fields
+  AndroidPluginConvention androidConvention
+  AndroidSdkToolsFactory sdkTools
+  def ant
+  
+  public AndroidPackageTask() {
+    // Initialize internal data
+    androidConvention = project.convention.plugins.android
+    sdkTools = new AndroidSdkToolsFactory(project)
+    ant = project.ant
+    
+    // Create necessary directories for this task
+    androidConvention.apkArchivePath.getParentFile().mkdirs()
+  }
+  
+  @TaskAction
+  protected void process() {
+    
+    if (keyStore != null && keyAlias != null) {
+      // Dont' sign - it'll sign with the provided key
+      createPackage(false)
+      // Sign with provided key
+      sign ()
+    } else {
+      // Sign with debug key
+      createPackage(true)
+    }
+    
+    // Create temporary file for the zipaligning
+    File temp = new File (project.libsDir, androidConvention.apkBaseName + "-unaligned.apk")
+    ant.copy(file: androidConvention.apkArchivePath.toString(), toFile: temp.toString())
+    // Do the alignment
+    zipAlign(temp, androidConvention.apkArchivePath)
+    // Remove temp file
+    temp.delete()
+    
+    logger.info("Final Package: " + androidConvention.apkArchivePath)
+  }
+  
+  private void sign() {
+    if (keyStorePassword == null || keyAliasPassword == null) {
+      def console = System.console()
+      keyStorePassword = new String(console.readPassword(
+          "Please enter keystore password (store:${keyStore}): "))
+      keyAliasPassword = new String(console.readPassword(
+          "Please enter password for alias '${keyAlias}': "))
+    }
+    
+    logger.info("Signing final apk...")
+    ant.signjar(jar: project.jar.archivePath,
+        signedjar: project.jar.archivePath,
+        keystore: keyStore,
+        storepass: keyStorePassword,
+        alias: keyAlias,
+        keypass: keyAliasPassword,
+        verbose: verbose)
+  }
+  
+  private void createPackage(boolean sign) {
+    logger.info("Converting compiled files and external libraries into ${androidConvention.intermediateDexFile}...")
+    ant.apply(executable: ant.dx, failonerror: true, parallel: true) {
+      arg(value: "--dex")
+      arg(value: "--output=${androidConvention.intermediateDexFile}")
+      if (verbose) arg(line: "--verbose")
+      //arg(path: project.sourceSets.main.classesDir)
+      fileset(file: project.jar.archivePath)
+    }
+    
+    logger.info("Packaging resources")
+    sdkTools.aaptexec.execute(command: 'package')
+    sdkTools.apkbuilder.execute('sign': sign, 'verbose': verbose)
+  }
+  
+  private void zipAlign(inPackage, outPackage) {
+    logger.info("Running zip align on final apk...")
+    ant.exec(executable: ant.zipalign, failonerror: true) {
+      if (verbose) arg(line: '-v')
+      arg(value: '-f')
+      arg(value: 4)
+      arg(path: inPackage)
+      arg(path: outPackage)
+    }
+  }
+}

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
@@ -1,14 +1,15 @@
 package com.jvoegele.gradle.tasks.android
 
-import groovy.lang.Closure;
+import groovy.lang.Closure
 
 import java.io.File
 
-import org.gradle.api.Task;
+import org.gradle.api.Task
 import org.gradle.api.internal.ConventionTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.TaskInputs
-import org.gradle.api.tasks.TaskOutputs
 
 import com.jvoegele.gradle.plugins.android.AndroidPluginConvention
 
@@ -20,55 +21,50 @@ import com.jvoegele.gradle.plugins.android.AndroidPluginConvention
 class AndroidPackageTask extends ConventionTask {
   
   // Public configuration properties
-  public String keyStore
-  public String keyAlias
-  public String keyStorePassword
-  public String keyAliasPassword
+  @Input public String keyStore
+  @Input public String keyAlias
+  @Input public String keyStorePassword
+  @Input public String keyAliasPassword
   public boolean verbose
 
+  // Inputs and outputs files and directories (to be determined dynamically)
+  @InputFile
+  public File getJarArchivePath() {
+    return project.jar.archivePath
+  }
+  @OutputFile
+  public File getApkArchivePath() {
+    return androidConvention.getApkArchivePath()
+  }
+  
   // Internal fields
   AndroidPluginConvention androidConvention
   AndroidSdkToolsFactory sdkTools
   def ant
-  
+
   public File getTempFile() {
     return new File (project.libsDir, androidConvention.getApkBaseName() + "-unaligned.apk")
   }
   
-//  public TaskOutputs getOutputs() {
-//    TaskOutputs to = super.getOutputs()
-//    to.file (androidConvention.getApkArchivePath())
-//    return to
-//  }
-
   public AndroidPackageTask() {
     // Initialize internal data
     androidConvention = project.convention.plugins.android
     sdkTools = new AndroidSdkToolsFactory(project)
     ant = project.ant
-    
+
+    // Set static inputs and outputs for this task
+    inputs.dir (androidConvention.resDir.absolutePath)
+    inputs.dir (androidConvention.assetsDir.absolutePath)
+    inputs.dir (androidConvention.nativeLibsDir.absolutePath)
+    inputs.file (androidConvention.androidManifest.absolutePath)
+    inputs.files (project.fileTree (dir: "project.sourceSets.main.classesDir", exclude: "**/*.class"))
   }
-
     
-  @Override
-  public Task configure(Closure closure) {
-
-    // Do the base configuration
-    Task configuredTask = super.configure(closure)
-    
-    // Declare inputs and outputs    
-    inputs.file (project.jar.archivePath)
-    outputs.file (androidConvention.getApkArchivePath())
-    
-    return configuredTask
-  }
-
-
   @TaskAction
   protected void process() {
     
     // Create necessary directories for this task
-    androidConvention.getApkArchivePath().getParentFile().mkdirs()
+    getApkArchivePath().getParentFile().mkdirs()
     
     if (keyStore != null && keyAlias != null) {
       // Dont' sign - it'll sign with the provided key
@@ -82,13 +78,11 @@ class AndroidPackageTask extends ConventionTask {
     
     // Create temporary file for the zipaligning
     File temp = getTempFile()
-    ant.copy(file: androidConvention.getApkArchivePath().toString(), toFile: temp.toString())
+    ant.copy(file: getApkArchivePath().toString(), toFile: temp.toString())
     // Do the alignment
-    zipAlign(temp, androidConvention.getApkArchivePath())
-    // Touch temp file (to correctly manage tasks' inputs and outputs, as the output is the temp file itself)
-    ant.touch (file: temp.getAbsolutePath());
+    zipAlign(temp, getApkArchivePath())
     
-    logger.info("Final Package: " + androidConvention.getApkArchivePath())
+    logger.info("Final Package: " + getApkArchivePath())
   }
   
   private void sign() {
@@ -101,8 +95,8 @@ class AndroidPackageTask extends ConventionTask {
     }
     
     logger.info("Signing final apk...")
-    ant.signjar(jar: androidConvention.getApkArchivePath().absolutePath,
-        signedjar: androidConvention.getApkArchivePath().absolutePath,
+    ant.signjar(jar: getApkArchivePath().absolutePath,
+        signedjar: getApkArchivePath().absolutePath,
         keystore: keyStore,
         storepass: keyStorePassword,
         alias: keyAlias,
@@ -116,7 +110,7 @@ class AndroidPackageTask extends ConventionTask {
       arg(value: "--dex")
       arg(value: "--output=${androidConvention.intermediateDexFile}")
       if (verbose) arg(line: "--verbose")
-      fileset(file: project.jar.archivePath)
+      fileset(file: getJarArchivePath())
     }
     
     logger.info("Packaging resources")

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
@@ -1,11 +1,16 @@
 package com.jvoegele.gradle.tasks.android
 
-import java.io.File;
+import groovy.lang.Closure;
 
-import com.jvoegele.gradle.plugins.android.AndroidPluginConvention 
-import com.jvoegele.gradle.tasks.android.AndroidSdkToolsFactory 
-import org.gradle.api.internal.ConventionTask;
-import org.gradle.api.tasks.TaskAction;
+import java.io.File
+
+import org.gradle.api.Task;
+import org.gradle.api.internal.ConventionTask
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskInputs
+import org.gradle.api.tasks.TaskOutputs
+
+import com.jvoegele.gradle.plugins.android.AndroidPluginConvention
 
 /**
  * 
@@ -30,13 +35,35 @@ class AndroidPackageTask extends ConventionTask {
     return new File (project.libsDir, androidConvention.getApkBaseName() + "-unaligned.apk")
   }
   
+//  public TaskOutputs getOutputs() {
+//    TaskOutputs to = super.getOutputs()
+//    to.file (androidConvention.getApkArchivePath())
+//    return to
+//  }
+
   public AndroidPackageTask() {
     // Initialize internal data
     androidConvention = project.convention.plugins.android
     sdkTools = new AndroidSdkToolsFactory(project)
     ant = project.ant
+    
   }
-  
+
+    
+  @Override
+  public Task configure(Closure closure) {
+
+    // Do the base configuration
+    Task configuredTask = super.configure(closure)
+    
+    // Declare inputs and outputs    
+    inputs.file (project.jar.archivePath)
+    outputs.file (androidConvention.getApkArchivePath())
+    
+    return configuredTask
+  }
+
+
   @TaskAction
   protected void process() {
     

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
@@ -74,8 +74,8 @@ class AndroidPackageTask extends ConventionTask {
     }
     
     logger.info("Signing final apk...")
-    ant.signjar(jar: project.jar.archivePath,
-        signedjar: project.jar.archivePath,
+    ant.signjar(jar: androidConvention.getApkArchivePath().absolutePath,
+        signedjar: androidConvention.getApkArchivePath().absolutePath,
         keystore: keyStore,
         storepass: keyStorePassword,
         alias: keyAlias,

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r7.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r7.groovy
@@ -14,14 +14,15 @@ class ApkBuilderTask_r7 extends AndroidAntTask {
    */
   public void execute(Map args) {
     assert ant != null
-    ant.apkbuilder(outfolder: project.buildDir,
+    ant.apkbuilder(outfolder: project.libsDir,
                    resourcefile: ant['resource.package.file.name'],
-                   apkfilepath: ant.properties["out.debug.unaligned.package"],
+                   apkfilepath: androidConvention.apkArchivePath,
                    signed: args.get('sign', false),
                    abifilter: '',
                    hascode: ant['manifest.hasCode'],
                    verbose: args.get('verbose', false)) {
       dex(path: androidConvention.intermediateDexFile)
+      // Takes resource files from the source folder - classes are processed by the dx command
       sourcefolder(path: project.sourceSets.main.classesDir)
       nativefolder(path: androidConvention.nativeLibsDir)
     }

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r7.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r7.groovy
@@ -16,7 +16,7 @@ class ApkBuilderTask_r7 extends AndroidAntTask {
     assert ant != null
     ant.apkbuilder(outfolder: project.libsDir,
                    resourcefile: ant['resource.package.file.name'],
-                   apkfilepath: androidConvention.apkArchivePath,
+                   apkfilepath: androidConvention.getApkArchivePath(),
                    signed: args.get('sign', false),
                    abifilter: '',
                    hascode: ant['manifest.hasCode'],

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ProGuard.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ProGuard.groovy
@@ -21,7 +21,6 @@ class ProGuard extends ConventionTask {
   String artifactName = "proguard"
   String artifactVersion = "4.4"
 
-//  boolean enabled = false
   boolean warn = false
   boolean note = false
   boolean obfuscate = false
@@ -31,7 +30,6 @@ class ProGuard extends ConventionTask {
     enabled = false
   }
   
-//  final File outJar = new File(project.libsDir, "classes.min.jar")
   public File getTempFile() {
     AndroidPluginConvention androidConvention = project.convention.plugins.android
     return new File (project.libsDir, androidConvention.getApkBaseName() + "-unproguarded.jar")
@@ -39,13 +37,8 @@ class ProGuard extends ConventionTask {
 
   @TaskAction
   protected void process() {
-//    if (!enabled) {
-////      ant.copy(file: project.jar.archivePath, tofile: outJar, overwrite: true)
-//      return
-//    }
 
     defineProGuardTask()
-//    ant.delete(file: outJar)
     String tempFilePath = getTempFile().getAbsolutePath()
     
     ant.proguard('warn': warn, 'obfuscate': obfuscate,
@@ -69,8 +62,6 @@ class ProGuard extends ConventionTask {
                  
     // Update the output file of this task
     ant.copy (file: tempFilePath, toFile: project.jar.archivePath, overwrite: true)
-    // Touch temp file (to correctly manage tasks' inputs and outputs, as the output is the temp file itself)
-    ant.touch (file: tempFilePath);
   }
 
   private boolean proGuardTaskDefined = false

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ProGuard.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ProGuard.groovy
@@ -21,10 +21,15 @@ class ProGuard extends ConventionTask {
   String artifactName = "proguard"
   String artifactVersion = "4.4"
 
-  boolean enabled = false
+//  boolean enabled = false
   boolean warn = false
   boolean note = false
   boolean obfuscate = false
+  
+  public ProGuard () {
+    // By default, this task is disabled - it has to be explicitly enabled by user in build.gradle
+    enabled = false
+  }
   
 //  final File outJar = new File(project.libsDir, "classes.min.jar")
   public File getTempFile() {
@@ -34,10 +39,10 @@ class ProGuard extends ConventionTask {
 
   @TaskAction
   protected void process() {
-    if (!enabled) {
-//      ant.copy(file: project.jar.archivePath, tofile: outJar, overwrite: true)
-      return
-    }
+//    if (!enabled) {
+////      ant.copy(file: project.jar.archivePath, tofile: outJar, overwrite: true)
+//      return
+//    }
 
     defineProGuardTask()
 //    ant.delete(file: outJar)

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ProGuard.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ProGuard.groovy
@@ -1,10 +1,14 @@
 package com.jvoegele.gradle.tasks.android;
 
+import java.io.File;
+
 import groovy.lang.MetaClass;
 import groovy.util.XmlSlurper;
 
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.tasks.TaskAction;
+
+import com.jvoegele.gradle.plugins.android.AndroidPluginConvention;
 
 /**
  * Uses the ProGuard tool to create a minimal JAR containing only those classes
@@ -17,30 +21,37 @@ class ProGuard extends ConventionTask {
   String artifactName = "proguard"
   String artifactVersion = "4.4"
 
-  boolean enabled = true
+  boolean enabled = false
   boolean warn = false
   boolean note = false
   boolean obfuscate = false
   
-  final File outJar = new File(project.libsDir, "classes.min.jar")
+//  final File outJar = new File(project.libsDir, "classes.min.jar")
+  public File getTempFile() {
+    AndroidPluginConvention androidConvention = project.convention.plugins.android
+    return new File (project.libsDir, androidConvention.getApkBaseName() + "-unproguarded.jar")
+  }
 
   @TaskAction
   protected void process() {
     if (!enabled) {
-      ant.copy(file: project.jar.archivePath, tofile: outJar, overwrite: true)
+//      ant.copy(file: project.jar.archivePath, tofile: outJar, overwrite: true)
       return
     }
 
     defineProGuardTask()
-    ant.delete(file: outJar)
+//    ant.delete(file: outJar)
+    String tempFilePath = getTempFile().getAbsolutePath()
+    
     ant.proguard('warn': warn, 'obfuscate': obfuscate,
                  'allowaccessmodification': true, 'overloadaggressively': true) {
       //injar(file: project.sourceSets.main.classesDir)
-      injar(path: project.libsDir)
-      project.configurations.compile.files.each { dependency ->
-        injar(file: dependency)
-      }
-      outjar(file: outJar)
+      injar(path: project.jar.archivePath)
+      // Is this truly necessary? Aren't they already in the jar archive above?
+//      project.configurations.compile.files.each { dependency ->
+//        injar(file: dependency)
+//      }
+      outjar(file: tempFilePath)
       libraryjar(file: ant['android.jar'])
       optimizations(filter: "!code/simplification/arithmetic")
       keep(access: 'public', 'extends': 'android.app.Activity')
@@ -50,6 +61,11 @@ class ProGuard extends ConventionTask {
       keep(access: 'public', 'name': '**.R')
       keep('name': '**.R$*')
     }
+                 
+    // Update the output file of this task
+    ant.copy (file: tempFilePath, toFile: project.jar.archivePath, overwrite: true)
+    // Touch temp file (to correctly manage tasks' inputs and outputs, as the output is the temp file itself)
+    ant.touch (file: tempFilePath);
   }
 
   private boolean proGuardTaskDefined = false

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ProcessAndroidResources.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ProcessAndroidResources.groovy
@@ -19,6 +19,7 @@ class ProcessAndroidResources extends ConventionTask {
     androidConvention = project.convention.plugins.android
     genDir = androidConvention.genDir
     
+    // Set input and output files and directories for this task
     inputs.file (androidConvention.androidManifest.absolutePath)
     inputs.dir (androidConvention.resDir.absolutePath)
     outputs.dir (genDir.absolutePath)

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ProcessAndroidResources.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ProcessAndroidResources.groovy
@@ -5,13 +5,27 @@ import groovy.lang.MetaClass;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.tasks.TaskAction;
 
+import com.jvoegele.gradle.plugins.android.AndroidPluginConvention;
+
 class ProcessAndroidResources extends ConventionTask {
   boolean verbose
 
+  AndroidPluginConvention androidConvention
+  File genDir
+
+  public ProcessAndroidResources () {
+    super()
+    
+    androidConvention = project.convention.plugins.android
+    genDir = androidConvention.genDir
+    
+    inputs.file (androidConvention.androidManifest.absolutePath)
+    inputs.dir (androidConvention.resDir.absolutePath)
+    outputs.dir (genDir.absolutePath)
+  }
+  
   @TaskAction
   protected void process() {
-    def androidConvention = project.convention.plugins.android
-    def genDir = androidConvention.genDir
     genDir.mkdirs()
     project.logger.info("Generating R.java / Manifest.java from the resources...")
     project.ant.exec(executable: ant.aapt, failonerror: "true") {


### PR DESCRIPTION
In this pull request there are implementation for the following issues:
#10 "cannot create signed application" - the sign step is now indipendent by the build type (release or debug) so it works in every workflow.
#6 "Implement task inputs and outputs" - supported in every android\* task; the proguard task is made optional using the standard enabled Gradle flag (set to false by default).
#9 "should allow setting signing password through system property" - signing password are properties of the packaging task: as such they can be configured freely using every way Gradle offers.
#13 "Unifying androidPackageDebug and androidPackageRelease" - now there is a single task, androidPackage, as discussed in the issue #13 itself, with all its benefits.

These make the plugin usage not fully compatible with past; in issue #13 there is an example (and in general it should be very simple to adapt existing build files).
