### PR TITLE
A few more changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 .classpath
 .gradle
 .settings
+bin

--- a/build.gradle
+++ b/build.gradle
@@ -34,3 +34,11 @@ dependencies {
 // Make sure all code is compiled, tested and checked before uploadArchives.
 uploadArchives.dependsOn ':build'
 
+clean << {
+    //TODO: will this work on Windows? I intentionally used the file() method so as
+    // to be platform independent, but I didn't test this outside MacOS/Linux
+    def gradleCacheDir = file("${System.properties['user.home']}/.gradle/cache")
+    def pluginCacheDir = file("$gradleCacheDir/$project.group/$project.name")
+    logger.warn "Clearing Gradle artifact cache at $pluginCacheDir"
+    ant.delete dir: pluginCacheDir
+} 

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -11,6 +11,7 @@ import com.jvoegele.gradle.tasks.android.AdbExec
 import com.jvoegele.gradle.tasks.android.AndroidPackageTask
 import com.jvoegele.gradle.tasks.android.ProGuard
 import com.jvoegele.gradle.tasks.android.ProcessAndroidResources
+import com.jvoegele.gradle.tasks.android.InstrumentationTestsTask
 
 /**
  * Gradle plugin that extends the Java plugin for Android development.
@@ -23,7 +24,8 @@ class AndroidPlugin implements Plugin<Project> {
   private static final ANDROID_PACKAGE_TASK_NAME = "androidPackage"
   private static final ANDROID_INSTALL_TASK_NAME = "androidInstall"
   private static final ANDROID_UNINSTALL_TASK_NAME = "androidUninstall"
-
+  private static final ANDROID_INSTRUMENT_TASK_NAME = "androidInstrument"
+  
   private static final PROPERTIES_FILES = ['local', 'build', 'default']
   private static final ANDROID_JARS = ['anttasks', 'sdklib', 'androidprefs', 'apkbuilder', 'jarutils']
 
@@ -36,7 +38,7 @@ class AndroidPlugin implements Plugin<Project> {
   private logger
 
   private androidProcessResourcesTask, proguardTask, androidPackageTask, 
-  androidInstallTask, androidUninstallTask
+  androidInstallTask, androidUninstallTask, androidInstrumentTask
 
   boolean verbose = false
 
@@ -122,6 +124,7 @@ class AndroidPlugin implements Plugin<Project> {
     defineAndroidPackageTask()
     defineAndroidInstallTask()
     defineAndroidUninstallTask()
+    defineAndroidInstrumentTask()
     defineTaskDependencies()
     configureTaskLogging()
   }
@@ -168,6 +171,13 @@ class AndroidPlugin implements Plugin<Project> {
       args 'uninstall', manifestPackage
     }
   }
+  
+  private void defineAndroidInstrumentTask() {
+    androidInstrumentTask = project.task(
+        ANDROID_INSTRUMENT_TASK_NAME,
+        description: "Runs instrumentation tests on a running emulator or device",
+        type: InstrumentationTestsTask)
+  }
 
   private void defineTaskDependencies() {
     project.tasks.compileJava.dependsOn(androidProcessResourcesTask)
@@ -175,6 +185,7 @@ class AndroidPlugin implements Plugin<Project> {
     androidPackageTask.dependsOn(proguardTask)
     project.tasks.assemble.dependsOn(androidPackageTask)
     androidInstallTask.dependsOn(project.tasks.assemble)
+    androidInstrumentTask.dependsOn(project.tasks.androidInstall)
   }
 
   private void configureTaskLogging() {

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AdbExec.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AdbExec.groovy
@@ -5,6 +5,8 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.TaskAction
 
+import com.jvoegele.gradle.tasks.android.exceptions.AdbErrorException;
+
 class AdbExec extends DefaultTask {
   def exec = new Exec()
   def stdout = new ByteArrayOutputStream() // output is small, we can safely read it into memory

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
@@ -99,14 +99,25 @@ class AndroidPackageTask extends ConventionTask {
         verbose: verbose)
   }
   
+  /**
+   * Creates a classes.dex file containing all classes required at runtime, i.e.
+   * all class files from the application itself, plus all its dependencies, and
+   * bundles it into the final APK.
+   * 
+   * @param sign whether the APK should be signed with the release key or not
+   */
   private void createPackage(boolean sign) {
     logger.info("Converting compiled files and external libraries into ${androidConvention.intermediateDexFile}...")
-    ant.apply(executable: ant.dx, failonerror: true, parallel: true) {
+    ant.apply(executable: ant.dx, failonerror: true, parallel: true, logError: true) {
       arg(value: "--dex")
       arg(value: "--output=${androidConvention.intermediateDexFile}")
       if (verbose) arg(line: "--verbose")
+      
+      // add classes from application JAR
       fileset(file: getJarArchivePath())
-      fileset(dir: androidConvention.externalLibsDir, includes: '*.jar')
+      
+      // add classes from application dependencies block
+      project.configurations.runtime.each { fileset file: it }
     }
     
     logger.info("Packaging resources")

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/InstrumentationTestsTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/InstrumentationTestsTask.groovy
@@ -1,0 +1,26 @@
+package com.jvoegele.gradle.tasks.android
+
+import com.jvoegele.gradle.tasks.android.exceptions.InstrumentationTestsFailedException;
+
+class InstrumentationTestsTask extends AdbExec {
+
+  def InstrumentationTestsTask() {
+    logger.info("Running instrumentation tests...")
+    
+    //TODO: make the test runner configurable or parse it from the manifest
+    def testRunner  = 'android.test.InstrumentationTestRunner'
+    def testPackage = ant['manifest.package']
+    
+    args "shell", "am instrument", "-w", "$testPackage/$testRunner"
+  } 
+  
+  @Override
+  def checkForErrors(stream) {
+    def reader = new InputStreamReader(new ByteArrayInputStream(stream.toByteArray()))
+    reader.eachLine {
+      if (it.matches("FAILURES!!!")) {
+        throw new InstrumentationTestsFailedException();
+      }
+    }
+  }
+}

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/exceptions/AdbErrorException.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/exceptions/AdbErrorException.groovy
@@ -1,4 +1,4 @@
-package com.jvoegele.gradle.tasks.android
+package com.jvoegele.gradle.tasks.android.exceptions
 
 import org.gradle.api.GradleException
 

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/exceptions/InstrumentationTestsFailedException.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/exceptions/InstrumentationTestsFailedException.groovy
@@ -1,0 +1,9 @@
+package com.jvoegele.gradle.tasks.android.exceptions;
+
+class InstrumentationTestsFailedException extends AdbErrorException {
+
+  def InstrumentationTestsFailedException() {
+    super("There were test failures")
+  }
+  
+}


### PR DESCRIPTION
1) contains the fix that adds the entire runtime dependency tree to the DEXer instead of just the application JAR
2) adds Eclipse's bin/ folders to gitignore (I prefer to let Eclipse and Gradle compile to different directories, so that they don't get in each other's way)
3) adds the clean hook that invalidate's the plugin in Gradle's repository cache. This is really useful when building the plugin yourself
