### PR TITLE
Corrected import org.gradle.util.OperatingSystem to org.gradle.os.Operati

### DIFF
--- a/src/integTest/groovy/com/jvoegele/gradle/android/support/TestProject.groovy
+++ b/src/integTest/groovy/com/jvoegele/gradle/android/support/TestProject.groovy
@@ -2,7 +2,7 @@ package com.jvoegele.gradle.android.support
 
 import org.gradle.GradleLauncher
 import org.gradle.api.Project
-import org.gradle.util.OperatingSystem
+import org.gradle.os.OperatingSystem
 
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue

--- a/src/integTest/groovy/com/jvoegele/gradle/android/support/ZipAlignVerifier.groovy
+++ b/src/integTest/groovy/com/jvoegele/gradle/android/support/ZipAlignVerifier.groovy
@@ -1,6 +1,6 @@
 package com.jvoegele.gradle.android.support
 
-import org.gradle.util.OperatingSystem
+import org.gradle.os.OperatingSystem
 
 import static org.junit.Assert.assertTrue
 


### PR DESCRIPTION
Corrected import org.gradle.util.OperatingSystem to org.gradle.os.OperatingSystem

org.gradle.util.OperatingSystem is no longer found in Gradle 1.0-milestone-5,
so we change it to org.gradle.os.OperatingSystem

Signed-off-by: Ealden Esto E. Escanan ealden@gmail.com
