### PR TITLE
IDEA config changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ bin
 .idea
 *.iml
 .DS_Store
+*.ipr
+*.iws

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin
 .DS_Store
 *.ipr
 *.iws
+out

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: 'eclipse'
+apply plugin: 'idea'
 
 version = '1.1.0-SNAPSHOT'
 group = 'com.jvoegele.gradle.plugins'

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,16 @@ task developerBuild {
     dependsOn build, integrationTest
 }
 
+idea {
+    module {
+        downloadSources = true
+        downloadJavadocs = true
+
+        testSourceDirs += file('src/integTest/groovy')
+        testSourceDirs += file('src/integTest/resources')
+    }
+}
+
 clean << {
     //TODO: will this work on Windows? I intentionally used the file() method so as
     // to be platform independent, but I didn't test this outside MacOS/Linux

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,10 @@ idea {
         testSourceDirs += file('src/integTest/groovy')
         testSourceDirs += file('src/integTest/resources')
     }
+    project {
+        jdkName = '1.6'
+        languageLevel = '1.6'
+    }
 }
 
 clean << {


### PR DESCRIPTION
Changes to build.gradle to fine tune settings in IntelliJ IDEA

Note that running `gradle developerBuild` does not succeed unless the branch 'gradle-1.0-milestone-5-fixes` is merged into this.  I am using the latest 1.0-milestone-5 which does not have org.gradle.util.OperatingSystem instead of org.gradle.os.OperatingSystem.
