### PR TITLE
Android R14 support

### DIFF
--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -112,7 +112,7 @@ class AndroidPlugin implements Plugin<Project> {
     def outDir = project.buildDir.absolutePath
     ant.property(name: "resource.package.file.name", value: "${project.name}.ap_")
 
-    ant.taskdef(name: 'setup', classname: 'com.android.ant.SetupTask', classpathref: 'android.antlibs')
+    ant.taskdef(name: 'setup', classname: 'com.android.ant.NewSetupTask', classpathref: 'android.antlibs')
 
     // The following properties are put in place by the setup task:
     // android.jar, android.aidl, aapt, aidl, and dx

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -130,7 +130,7 @@ class AndroidPlugin implements Plugin<Project> {
               targetApiOut: "target.api")
 
     ant.taskdef(name: "xpath", classname: "com.android.ant.XPathTask", classpathref: "android.antlibs")
-    ant.taskdef(name: "aaptexec", classname: "com.android.ant.AaptExecLoopTask", classpathref: "android.antlibs")
+    ant.taskdef(name: "aaptexec", classname: "com.android.ant.AaptExecTask", classpathref: "android.antlibs")
     ant.taskdef(name: "apkbuilder", classname: "com.android.ant.ApkBuilderTask", classpathref: "android.antlibs")
 
     ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/@package", output: "manifest.package")

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -116,7 +116,18 @@ class AndroidPlugin implements Plugin<Project> {
 
     // The following properties are put in place by the setup task:
     // android.jar, android.aidl, aapt, aidl, and dx
-    ant.setup()
+    ant.setup(projectTypeOut: "android.project.type",
+              androidJarFileOut: "android.jar",
+              androidAidlFileOut: "android.aidl",
+              renderScriptExeOut: "renderscript",
+              renderScriptIncludeDirOut: "android.rs",
+              bootclasspathrefOut: "android.target.classpath",
+              projectLibrariesRootOut: "project.libraries",
+              projectLibrariesJarsOut: "project.libraries.jars",
+              projectLibrariesResOut: "project.libraries.res",
+              projectLibrariesPackageOut: "project.libraries.package",
+              projectLibrariesLibsOut: "project.libraries.libs",
+              targetApiOut: "target.api")
 
     ant.taskdef(name: "xpath", classname: "com.android.ant.XPathTask", classpathref: "android.antlibs")
     ant.taskdef(name: "aaptexec", classname: "com.android.ant.AaptExecLoopTask", classpathref: "android.antlibs")

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -116,7 +116,7 @@ class AndroidPlugin implements Plugin<Project> {
 
     // The following properties are put in place by the setup task:
     // android.jar, android.aidl, aapt, aidl, and dx
-    ant.setup('import': false)
+    ant.setup()
 
     ant.taskdef(name: "xpath", classname: "com.android.ant.XPathTask", classpathref: "android.antlibs")
     ant.taskdef(name: "aaptexec", classname: "com.android.ant.AaptExecLoopTask", classpathref: "android.antlibs")

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -133,6 +133,8 @@ class AndroidPlugin implements Plugin<Project> {
     ant.taskdef(name: "aaptexec", classname: "com.android.ant.AaptExecTask", classpathref: "android.antlibs")
     ant.taskdef(name: "apkbuilder", classname: "com.android.ant.ApkBuilderTask", classpathref: "android.antlibs")
 
+    ant.property(name: "aapt", location: new File(platformToolsDir, "aapt${ant['exe']}"))
+
     ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/@package", output: "manifest.package")
     // TODO: there can be several instrumentations defined
     ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/instrumentation/@android:targetPackage", output: "tested.manifest.package")

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -101,6 +101,7 @@ class AndroidPlugin implements Plugin<Project> {
     }
 
     ant.condition('property': "exe", value: ".exe", 'else': "") { os(family: "windows") }
+    ant.condition('property': "bat", value: ".bat", 'else': "") { os(family: "windows") }
     if (platformToolsDir.exists()) { // since SDK r8, adb is moved from tools to platform-tools
       ant.property(name: "adb", location: new File(platformToolsDir, "adb${ant['exe']}"))
     } else {
@@ -134,6 +135,7 @@ class AndroidPlugin implements Plugin<Project> {
     ant.taskdef(name: "apkbuilder", classname: "com.android.ant.ApkBuilderTask", classpathref: "android.antlibs")
 
     ant.property(name: "aapt", location: new File(platformToolsDir, "aapt${ant['exe']}"))
+    ant.property(name: "dx", location: new File(platformToolsDir, "dx${ant['bat']}"))
 
     ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/@package", output: "manifest.package")
     // TODO: there can be several instrumentations defined

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AaptExecTask_r14.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AaptExecTask_r14.groovy
@@ -1,0 +1,27 @@
+package com.jvoegele.gradle.tasks.android
+
+class AaptExecTask_r14 extends AndroidAntTask {
+
+  public AaptExecTask_r14(project) {
+    super(project);
+  }
+
+  /* (non-Javadoc)
+   * @see com.jvoegele.gradle.tasks.android.AndroidAntTask#execute(java.util.Map)
+   */
+  @Override
+  public void execute(Map args) {
+    ant.aaptexec(executable: ant.aapt,
+                 command: args.get('command', 'package'),
+                 manifest: androidConvention.androidManifest.path,
+                 assets: androidConvention.assetsDir,
+                 androidjar: ant['android.jar'],
+                 apkfolder: project.libsDir,
+                 resourcefilename: project.name + ".ap_",
+                 projectLibrariesResName: 'project.libraries.res',
+                 projectLibrariesPackageName: 'project.libraries.package') {
+      res(path: androidConvention.resDir.path)
+    }
+  }
+
+}

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSdkToolsFactory.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSdkToolsFactory.groovy
@@ -54,8 +54,10 @@ class AndroidSdkToolsFactory {
   public AndroidAntTask getAaptexec() {
     if (this.androidSdkToolsRevision < 8) {
       return new AaptExecTask_r7(project)
-    } else {
+    } else if (this.androidSdkToolsRevision < 14) {
       return new AaptExecTask_r8(project)
+    } else {
+      return new AaptExecTask_r14(project)
     }
   }
 }

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSdkToolsFactory.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSdkToolsFactory.groovy
@@ -46,8 +46,10 @@ class AndroidSdkToolsFactory {
       return new ApkBuilderTask_r6(project)
     } else if (this.androidSdkToolsRevision < 8) {
       return new ApkBuilderTask_r7(project)
-    } else {
+    } else if (this.androidSdkToolsRevision < 14) {
       return new ApkBuilderTask_r8(project)
+    } else {
+      return new ApkBuilderTask_r14(project)
     }
   }
 

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r14.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r14.groovy
@@ -1,0 +1,39 @@
+package com.jvoegele.gradle.tasks.android
+
+class ApkBuilderTask_r14 extends AndroidAntTask {
+  public ApkBuilderTask_r14(project) {
+    super(project)
+  }
+
+  /**
+   * Execute the apkbuilder task.
+   * @param args Map of keyword arguments.  Supported keywords are sign and
+   *             verbose, both of which should be boolean values if provided.
+   */
+  public void execute(Map args) {
+    assert ant != null
+    ant.apkbuilder(outfolder: project.libsDir,
+                   resourcefile: ant['resource.package.file.name'],
+                   apkfilepath: androidConvention.getApkArchivePath(),
+                   debugsigning: args.get('sign', false),
+                   hascode: ant['manifest.hasCode'],
+                   verbose: args.get('verbose', false)) {
+      dex(path: androidConvention.intermediateDexFile)
+      // Takes resource files from the source folder - classes are processed by the dx command
+      sourcefolder(path: project.sourceSets.main.classesDir)
+      nativefolder(path: androidConvention.nativeLibsDir)
+    }
+/*
+            <apkbuilder>
+                <dex path="${intermediate.dex.file}"/>
+                <sourcefolder path="${source.absolute.dir}" />
+                <sourcefolder refid="android.libraries.src" />
+                <jarfolder path="${external.libs.absolute.dir}" />
+                <jarfolder refid="android.libraries.libs" />
+                <nativefolder path="${native.libs.absolute.dir}" />
+                <nativefolder refid="android.libraries.libs" />
+                <extra-jars/>
+
+ */
+  }
+}

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r14.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r14.groovy
@@ -14,13 +14,13 @@ class ApkBuilderTask_r14 extends AndroidAntTask {
     assert ant != null
     ant.apkbuilder(outfolder: project.libsDir,
                    resourcefile: ant['resource.package.file.name'],
-                   apkfilepath: androidConvention.getApkArchivePath(),
+                   apkfilepath: androidConvention.unsignedArchivePath,
                    debugsigning: args.get('sign', false),
                    hascode: ant['manifest.hasCode'],
                    verbose: args.get('verbose', false)) {
       dex(path: androidConvention.intermediateDexFile)
       // Takes resource files from the source folder - classes are processed by the dx command
-      sourcefolder(path: project.sourceSets.main.classesDir)
+      sourcefolder(path: project.sourceSets.main.output.classesDir)
       nativefolder(path: androidConvention.nativeLibsDir)
     }
 /*


### PR DESCRIPTION
This pull request aims to allow gradle-android-plugin to support Android R14 / Ice Cream Sandwich.  It looks like a lot of things changed in the Ant build system of Android, hence why it doesn't work with the current gradle-android-plugin.

This is based off from the master branch, with #32 merged in as I am using Gradle 1.0-milestone-6.  This passes `gradle developerBuild` and I tried to use it in a simple project that I have here.  Seems to work correctly.

I tried to document all the changes I did, hence the multiple commits.  I can always squash them and force-update this pull request if necessary.

I do have a concern with R14, as I had to made a couple of changes in AndroidPlugin specifically androidSetup() to make it work.  I noticed that release-specific versions of AaptExecTask and ApkBuilderTask are provided - maybe we can do the same for androidSetup()?
