### PR TITLE
R13 Backwards Compatibility

### DIFF
--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AbstractAndroidSetup.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AbstractAndroidSetup.groovy
@@ -1,0 +1,9 @@
+package com.jvoegele.gradle.plugins.android
+
+abstract class AbstractAndroidSetup implements AndroidSetup {
+  protected project
+	
+  AbstractAndroidSetup(project) {
+    this.project = project
+  }
+}

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -69,32 +69,9 @@ class AndroidPlugin implements Plugin<Project> {
 
   private void androidSetup() {
 	registerPropertyFiles()
+	determineAndroidDirs()
 	
     def ant = project.ant
-
-    // Determine the sdkDir value.
-    // First, let's try the sdk.dir property in local.properties file.
-    try {
-      sdkDir = ant['sdk.dir']
-    } catch (MissingPropertyException e) {
-      sdkDir = null
-    }
-    if (sdkDir == null || sdkDir.length() == 0) {
-      // No local.properties and/or no sdk.dir property: let's try ANDROID_HOME
-      sdkDir = System.getenv("ANDROID_HOME")
-      // Propagate it to the Gradle's Ant environment
-      if (sdkDir != null) {
-        ant.setProperty("sdk.dir", sdkDir)
-      }
-    }
-
-    // Check for sdkDir correctly valued, and in case throw an error
-    if (sdkDir == null || sdkDir.length() == 0) {
-      throw new MissingPropertyException("Unable to find location of Android SDK. Please read documentation.")
-    }
-
-    toolsDir = new File(sdkDir, "tools")
-    platformToolsDir = new File(sdkDir, "platform-tools")
 
     ant.path(id: 'android.antlibs') {
       ANDROID_JARS.each { pathelement(path: "${sdkDir}/tools/lib/${it}.jar") }
@@ -153,6 +130,35 @@ class AndroidPlugin implements Plugin<Project> {
     def ant = project.ant
 
     PROPERTIES_FILES.each { ant.property(file: "${it}.properties") }
+  }
+
+  private void determineAndroidDirs() {
+	def ant = project.ant
+
+	// Determine the sdkDir value.
+    // First, let's try the sdk.dir property in local.properties file.
+    try {
+      sdkDir = ant['sdk.dir']
+    } catch (MissingPropertyException e) {
+      sdkDir = null
+    }
+
+    if (sdkDir == null || sdkDir.length() == 0) {
+      // No local.properties and/or no sdk.dir property: let's try ANDROID_HOME
+      sdkDir = System.getenv("ANDROID_HOME")
+      // Propagate it to the Gradle's Ant environment
+      if (sdkDir != null) {
+        ant.setProperty("sdk.dir", sdkDir)
+      }
+    }
+
+    // Check for sdkDir correctly valued, and in case throw an error
+    if (sdkDir == null || sdkDir.length() == 0) {
+      throw new MissingPropertyException("Unable to find location of Android SDK. Please read documentation.")
+    }
+
+    toolsDir = new File(sdkDir, "tools")
+    platformToolsDir = new File(sdkDir, "platform-tools")
   }
 
   private void defineTasks() {

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -39,9 +39,6 @@ class AndroidPlugin implements Plugin<Project> {
   private static final ANDROID_JARS = ['anttasks', 'sdklib', 'androidprefs', 'apkbuilder', 'jarutils']
 
   private AndroidPluginConvention androidConvention
-  private sdkDir
-  private toolsDir
-  private platformToolsDir // used since SDK r8, so check if it exists before using!
 
   private Project project
   private logger
@@ -71,56 +68,9 @@ class AndroidPlugin implements Plugin<Project> {
 	registerPropertyFiles()
 	determineAndroidDirs()
 	registerAndroidJars()
-	
-    def ant = project.ant
 
-    ant.condition('property': "exe", value: ".exe", 'else': "") { os(family: "windows") }
-    ant.condition('property': "bat", value: ".bat", 'else': "") { os(family: "windows") }
-    if (platformToolsDir.exists()) { // since SDK r8, adb is moved from tools to platform-tools
-      ant.property(name: "adb", location: new File(platformToolsDir, "adb${ant['exe']}"))
-    } else {
-      ant.property(name: "adb", location: new File(toolsDir, "adb${ant['exe']}"))
-    }
-    ant.property(name: "zipalign", location: new File(toolsDir, "zipalign${ant['exe']}"))
-    ant.property(name: 'adb.device.arg', value: '')
-
-    def outDir = project.buildDir.absolutePath
-    ant.property(name: "resource.package.file.name", value: "${project.name}.ap_")
-
-    ant.taskdef(name: 'setup', classname: 'com.android.ant.NewSetupTask', classpathref: 'android.antlibs')
-
-    // The following properties are put in place by the setup task:
-    // android.jar, android.aidl, aapt, aidl, and dx
-    ant.setup(projectTypeOut: "android.project.type",
-              androidJarFileOut: "android.jar",
-              androidAidlFileOut: "android.aidl",
-              renderScriptExeOut: "renderscript",
-              renderScriptIncludeDirOut: "android.rs",
-              bootclasspathrefOut: "android.target.classpath",
-              projectLibrariesRootOut: "project.libraries",
-              projectLibrariesJarsOut: "project.libraries.jars",
-              projectLibrariesResOut: "project.libraries.res",
-              projectLibrariesPackageOut: "project.libraries.package",
-              projectLibrariesLibsOut: "project.libraries.libs",
-              targetApiOut: "target.api")
-
-    ant.taskdef(name: "xpath", classname: "com.android.ant.XPathTask", classpathref: "android.antlibs")
-    ant.taskdef(name: "aaptexec", classname: "com.android.ant.AaptExecTask", classpathref: "android.antlibs")
-    ant.taskdef(name: "apkbuilder", classname: "com.android.ant.ApkBuilderTask", classpathref: "android.antlibs")
-
-    ant.property(name: "aapt", location: new File(platformToolsDir, "aapt${ant['exe']}"))
-    ant.property(name: "dx", location: new File(platformToolsDir, "dx${ant['bat']}"))
-
-    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/@package", output: "manifest.package")
-    // TODO: there can be several instrumentations defined
-    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/instrumentation/@android:targetPackage", output: "tested.manifest.package")
-    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/application/@android:hasCode",
-              output: "manifest.hasCode", 'default': "true")
-
-    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/instrumentation/@android:name", output: "android.instrumentation")
-    if (ant['android.instrumentation']) {
-      androidConvention.instrumentationTestsRunner = ant['android.instrumentation']
-    }
+    def setupFactory = new AndroidSetupFactory(project)
+    setupFactory.androidSetup.setup()
   }
 
   private void registerPropertyFiles() {
@@ -131,7 +81,8 @@ class AndroidPlugin implements Plugin<Project> {
 
   private void determineAndroidDirs() {
 	def ant = project.ant
-
+	def sdkDir
+	
 	// Determine the sdkDir value.
     // First, let's try the sdk.dir property in local.properties file.
     try {
@@ -153,13 +104,11 @@ class AndroidPlugin implements Plugin<Project> {
     if (sdkDir == null || sdkDir.length() == 0) {
       throw new MissingPropertyException("Unable to find location of Android SDK. Please read documentation.")
     }
-
-    toolsDir = new File(sdkDir, "tools")
-    platformToolsDir = new File(sdkDir, "platform-tools")
   }
 
   private void registerAndroidJars() {
     def ant = project.ant
+	def sdkDir = ant['sdk.dir']
 
     ant.path(id: 'android.antlibs') {
       ANDROID_JARS.each { pathelement(path: "${sdkDir}/tools/lib/${it}.jar") }

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -70,12 +70,9 @@ class AndroidPlugin implements Plugin<Project> {
   private void androidSetup() {
 	registerPropertyFiles()
 	determineAndroidDirs()
+	registerAndroidJars()
 	
     def ant = project.ant
-
-    ant.path(id: 'android.antlibs') {
-      ANDROID_JARS.each { pathelement(path: "${sdkDir}/tools/lib/${it}.jar") }
-    }
 
     ant.condition('property': "exe", value: ".exe", 'else': "") { os(family: "windows") }
     ant.condition('property': "bat", value: ".bat", 'else': "") { os(family: "windows") }
@@ -159,6 +156,14 @@ class AndroidPlugin implements Plugin<Project> {
 
     toolsDir = new File(sdkDir, "tools")
     platformToolsDir = new File(sdkDir, "platform-tools")
+  }
+
+  private void registerAndroidJars() {
+    def ant = project.ant
+
+    ant.path(id: 'android.antlibs') {
+      ANDROID_JARS.each { pathelement(path: "${sdkDir}/tools/lib/${it}.jar") }
+    }	
   }
 
   private void defineTasks() {

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -68,9 +68,9 @@ class AndroidPlugin implements Plugin<Project> {
   }
 
   private void androidSetup() {
+	registerPropertyFiles()
+	
     def ant = project.ant
-
-    PROPERTIES_FILES.each { ant.property(file: "${it}.properties") }
 
     // Determine the sdkDir value.
     // First, let's try the sdk.dir property in local.properties file.
@@ -147,6 +147,12 @@ class AndroidPlugin implements Plugin<Project> {
     if (ant['android.instrumentation']) {
       androidConvention.instrumentationTestsRunner = ant['android.instrumentation']
     }
+  }
+
+  private void registerPropertyFiles() {
+    def ant = project.ant
+
+    PROPERTIES_FILES.each { ant.property(file: "${it}.properties") }
   }
 
   private void defineTasks() {

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup.groovy
@@ -1,0 +1,5 @@
+package com.jvoegele.gradle.plugins.android
+
+interface AndroidSetup {
+  void setup()
+}

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetupFactory.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetupFactory.groovy
@@ -1,0 +1,13 @@
+package com.jvoegele.gradle.plugins.android
+
+class AndroidSetupFactory {
+  private project
+
+  AndroidSetupFactory(project) {
+	this.project = project
+  }
+
+  AndroidSetup getAndroidSetup() {
+	return new AndroidSetup_r14(project)
+  } 
+}

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetupFactory.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetupFactory.groovy
@@ -1,13 +1,35 @@
 package com.jvoegele.gradle.plugins.android
 
 class AndroidSetupFactory {
+  private static final String SOURCE_PROPERTIES_FILE = 'source.properties'
+  private static final String PKG_REVISION_PROPERTY = 'Pkg.Revision'
+
   private project
+  private int toolsRevision = -1
 
   AndroidSetupFactory(project) {
 	this.project = project
   }
 
+  int getAndroidSdkToolsRevision() {
+    if (toolsRevision < 0) {
+      def ant = project.ant
+      def toolsDir = new File(ant['sdk.dir'], 'tools')
+      assert toolsDir.exists()
+      def sourcePropertiesFile = new File(toolsDir, SOURCE_PROPERTIES_FILE)
+      assert sourcePropertiesFile.exists()
+      ant.property(file: sourcePropertiesFile)
+      toolsRevision = Integer.parseInt(ant[PKG_REVISION_PROPERTY])
+    }
+
+    return toolsRevision
+  }
+
   AndroidSetup getAndroidSetup() {
-	return new AndroidSetup_r14(project)
+	if (this.androidSdkToolsRevision < 14) {
+	  return new AndroidSetup_r13(project)
+	} else {
+	  return new AndroidSetup_r14(project)
+	}
   } 
 }

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup_r13.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup_r13.groovy
@@ -1,0 +1,48 @@
+package com.jvoegele.gradle.plugins.android
+
+class AndroidSetup_r13 extends AbstractAndroidSetup {
+  AndroidSetup_r13(project) {
+	super(project)
+  }
+
+  void setup() {
+	def ant = project.ant
+	def androidConvention = project.convention.plugins.android
+
+	def sdkDir = ant['sdk.dir']
+	def toolsDir = new File(sdkDir, "tools")
+    def platformToolsDir = new File(sdkDir, "platform-tools")
+
+	ant.condition('property': "exe", value: ".exe", 'else': "") { os(family: "windows") }
+	if (platformToolsDir.exists()) { // since SDK r8, adb is moved from tools to platform-tools
+      ant.property(name: "adb", location: new File(platformToolsDir, "adb${ant['exe']}"))
+    } else {
+      ant.property(name: "adb", location: new File(toolsDir, "adb${ant['exe']}"))
+    }
+    ant.property(name: "zipalign", location: new File(toolsDir, "zipalign${ant['exe']}"))
+    ant.property(name: 'adb.device.arg', value: '')
+
+    def outDir = project.buildDir.absolutePath
+    ant.property(name: "resource.package.file.name", value: "${project.name}.ap_")
+
+    ant.taskdef(name: 'setup', classname: 'com.android.ant.SetupTask', classpathref: 'android.antlibs')
+
+    // The following properties are put in place by the setup task:
+    // android.jar, android.aidl, aapt, aidl, and dx
+    ant.setup('import': false)
+
+    ant.taskdef(name: "xpath", classname: "com.android.ant.XPathTask", classpathref: "android.antlibs")
+    ant.taskdef(name: "aaptexec", classname: "com.android.ant.AaptExecLoopTask", classpathref: "android.antlibs")
+    ant.taskdef(name: "apkbuilder", classname: "com.android.ant.ApkBuilderTask", classpathref: "android.antlibs")
+
+    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/@package", output: "manifest.package")
+    // TODO: there can be several instrumentations defined
+    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/instrumentation/@android:targetPackage", output: "tested.manifest.package")
+    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/application/@android:hasCode", output: "manifest.hasCode", 'default': "true")
+
+    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/instrumentation/@android:name", output: "android.instrumentation")
+    if (ant['android.instrumentation']) {
+        androidConvention.instrumentationTestsRunner = ant['android.instrumentation']
+    }
+  }
+}

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup_r14.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup_r14.groovy
@@ -1,0 +1,63 @@
+package com.jvoegele.gradle.plugins.android
+
+class AndroidSetup_r14 extends AbstractAndroidSetup {
+  AndroidSetup_r14(project) {
+	super(project)
+  }
+
+  void setup() {
+	def ant = project.ant
+	def androidConvention = project.convention.plugins.android
+	
+	def sdkDir = ant['sdk.dir']
+	def toolsDir = new File(sdkDir, "tools")
+    def platformToolsDir = new File(sdkDir, "platform-tools")
+	
+    ant.condition('property': "exe", value: ".exe", 'else': "") { os(family: "windows") }
+    ant.condition('property': "bat", value: ".bat", 'else': "") { os(family: "windows") }
+    if (platformToolsDir.exists()) { // since SDK r8, adb is moved from tools to platform-tools
+      ant.property(name: "adb", location: new File(platformToolsDir, "adb${ant['exe']}"))
+    } else {
+      ant.property(name: "adb", location: new File(toolsDir, "adb${ant['exe']}"))
+    }
+    ant.property(name: "zipalign", location: new File(toolsDir, "zipalign${ant['exe']}"))
+    ant.property(name: 'adb.device.arg', value: '')
+
+    def outDir = project.buildDir.absolutePath
+    ant.property(name: "resource.package.file.name", value: "${project.name}.ap_")
+
+    ant.taskdef(name: 'setup', classname: 'com.android.ant.NewSetupTask', classpathref: 'android.antlibs')
+
+    // The following properties are put in place by the setup task:
+    // android.jar, android.aidl, aapt, aidl, and dx
+    ant.setup(projectTypeOut: "android.project.type",
+              androidJarFileOut: "android.jar",
+              androidAidlFileOut: "android.aidl",
+              renderScriptExeOut: "renderscript",
+              renderScriptIncludeDirOut: "android.rs",
+              bootclasspathrefOut: "android.target.classpath",
+              projectLibrariesRootOut: "project.libraries",
+              projectLibrariesJarsOut: "project.libraries.jars",
+              projectLibrariesResOut: "project.libraries.res",
+              projectLibrariesPackageOut: "project.libraries.package",
+              projectLibrariesLibsOut: "project.libraries.libs",
+              targetApiOut: "target.api")
+
+    ant.taskdef(name: "xpath", classname: "com.android.ant.XPathTask", classpathref: "android.antlibs")
+    ant.taskdef(name: "aaptexec", classname: "com.android.ant.AaptExecTask", classpathref: "android.antlibs")
+    ant.taskdef(name: "apkbuilder", classname: "com.android.ant.ApkBuilderTask", classpathref: "android.antlibs")
+
+    ant.property(name: "aapt", location: new File(platformToolsDir, "aapt${ant['exe']}"))
+    ant.property(name: "dx", location: new File(platformToolsDir, "dx${ant['bat']}"))
+
+    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/@package", output: "manifest.package")
+    // TODO: there can be several instrumentations defined
+    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/instrumentation/@android:targetPackage", output: "tested.manifest.package")
+    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/application/@android:hasCode", output: "manifest.hasCode", 'default': "true")
+
+    ant.xpath(input: androidConvention.androidManifest, expression: "/manifest/instrumentation/@android:name", output: "android.instrumentation")
+    if (ant['android.instrumentation']) {
+      androidConvention.instrumentationTestsRunner = ant['android.instrumentation']
+    }	
+  }
+}


### PR DESCRIPTION
This essentially allows gradle-android-plugin to be built again using R13 (and earlier) or R14 (and later) Android SDKs.  The androidSetup() method in AndroidPlugin has been externalized into classes that are specific to releases, similar to what is done with the task classes.
