### PR TITLE
Changes to meet Sonatype's requirements

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ apply plugin: 'idea'
 version = '1.1.0-SNAPSHOT'
 group = 'com.jvoegele.gradle.plugins'
 
+def artifact = 'gradle-android-plugin'
+
 configurations {
     sshDeploy
 
@@ -30,7 +32,7 @@ uploadArchives {
         //configuration = configurations.sshDeploy
         //repository(url: "scp://jvoegele@chilco.textdrive.com/web/public/maven2")
         repository(url: "file:///tmp/maven2")
-        pom.artifactId = 'gradle-android-plugin'
+        pom.artifactId = artifact
     }
 }
 
@@ -91,12 +93,18 @@ clean << {
     ant.delete dir: pluginCacheDir
 }
 
+jar {
+    baseName = artifact
+}
+
 task sourcesJar(type: Jar, dependsOn: classes) {
+    baseName = artifact
     classifier = 'sources'
     from sourceSets.main.allSource
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
+    baseName = artifact
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
@@ -116,7 +124,7 @@ task generatePom << {
     pom {
         project {
             groupId project.name
-            artifactId 'gradle-android-plugin'
+            artifactId artifact
             version project.version
             packaging 'jar'
             name 'Gradle Android Plugin'

--- a/build.gradle
+++ b/build.gradle
@@ -93,3 +93,63 @@ clean << {
 task wrapper(type: Wrapper) {
     gradleVersion = '1.0-milestone-6'
 }
+
+task generatePom << {
+    def generatedPomFileName = 'pom.xml'
+
+    pom {
+        project {
+            groupId project.name
+            artifactId 'android-plugin'
+            version project.version
+            packaging 'jar'
+            name 'Gradle Android Plugin'
+            description 'Android plugin for the Gradle build system.'
+            url 'https://github.com/jvoegele/gradle-android-plugin'
+            licenses {
+                license {
+                    name 'The Apache Software License, Version 2.0'
+                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    distribution 'repo'
+                }
+            }
+            scm {
+                url 'https://github.com/jvoegele/gradle-android-plugin'
+                connection 'scm:git://github.com/jvoegele/gradle-android-plugin.git'
+                developerConnection 'scm:git@github.com:jvoegele/gradle-android-plugin.git'
+            }
+            developers {
+                developer {
+                    id 'jvoegele'
+                    name 'Jason Voegele'
+                    email 'jason.voegele@gmail.com'
+                }
+                developer {
+                    id 'kaeppler'
+                    name 'Matthias Käppler'
+                    email 'm.kaeppler@googlemail.com'
+                }
+                developer {
+                    id 'think01'
+                    name 'Fabio Da Soghe'
+                    email 'fabiodasoghe@gmail.com'
+                }
+                developer {
+                    id 'Ladicek'
+                    name 'Ladislav Thon'
+                    email 'ladicek@gmail.com'
+                }
+                developer {
+                    id 'ealden'
+                    name 'Ealden Esto E. Escañan'
+                    email 'ealden@gmail.com'
+                }
+                developer {
+                    id 'erdi'
+                    name 'Marcin Erdmann'
+                    email 'erdi84@gmail.com'
+                }
+            }
+        }
+    }.writeTo("$buildDir/pom.xml")
+}

--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ task generatePom << {
                 }
                 developer {
                     id 'ealden'
-                    name 'Ealden Esto E. Escañan'
+                    name 'Ealden Esto E. Escanan'
                     email 'ealden@gmail.com'
                 }
                 developer {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 
 version = '1.1.0-SNAPSHOT'
-group = 'com.jvoegele.gradle.plugins'
+group = 'org.gradle.api.plugins'
 
 def artifact = 'gradle-android-plugin'
 

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ task generatePom << {
 
     pom {
         project {
-            groupId project.name
+            groupId project.group
             artifactId artifact
             version project.version
             packaging 'jar'

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ version = '1.1.0-SNAPSHOT'
 group = 'org.gradle.api.plugins'
 
 def artifact = 'gradle-android-plugin'
+project.artifact = artifact
 
 configurations {
     sshDeploy
@@ -32,7 +33,7 @@ uploadArchives {
         //configuration = configurations.sshDeploy
         //repository(url: "scp://jvoegele@chilco.textdrive.com/web/public/maven2")
         repository(url: "file:///tmp/maven2")
-        pom.artifactId = artifact
+        pom.project(pomConfiguration)
     }
 }
 
@@ -122,58 +123,62 @@ task generatePom << {
     def generatedPomFileName = 'pom.xml'
 
     pom {
-        project {
-            groupId project.group
-            artifactId artifact
-            version project.version
-            packaging 'jar'
-            name 'Gradle Android Plugin'
-            description 'Android plugin for the Gradle build system.'
-            url 'https://github.com/jvoegele/gradle-android-plugin'
-            licenses {
-                license {
-                    name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    distribution 'repo'
-                }
-            }
-            scm {
-                url 'https://github.com/jvoegele/gradle-android-plugin'
-                connection 'scm:git://github.com/jvoegele/gradle-android-plugin.git'
-                developerConnection 'scm:git@github.com:jvoegele/gradle-android-plugin.git'
-            }
-            developers {
-                developer {
-                    id 'jvoegele'
-                    name 'Jason Voegele'
-                    email 'jason.voegele@gmail.com'
-                }
-                developer {
-                    id 'kaeppler'
-                    name 'Matthias Käppler'
-                    email 'm.kaeppler@googlemail.com'
-                }
-                developer {
-                    id 'think01'
-                    name 'Fabio Da Soghe'
-                    email 'fabiodasoghe@gmail.com'
-                }
-                developer {
-                    id 'Ladicek'
-                    name 'Ladislav Thon'
-                    email 'ladicek@gmail.com'
-                }
-                developer {
-                    id 'ealden'
-                    name 'Ealden Esto E. Escanan'
-                    email 'ealden@gmail.com'
-                }
-                developer {
-                    id 'erdi'
-                    name 'Marcin Erdmann'
-                    email 'erdi84@gmail.com'
-                }
+        project(pomConfiguration)
+    }.writeTo("$buildDir/pom.xml")
+}
+
+def getPomConfiguration() {
+    return {
+        groupId project.group
+        artifactId project.artifact
+        version project.version
+        packaging 'jar'
+        name 'Gradle Android Plugin'
+        description 'Android plugin for the Gradle build system.'
+        url 'https://github.com/jvoegele/gradle-android-plugin'
+        licenses {
+            license {
+                name 'The Apache Software License, Version 2.0'
+                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                distribution 'repo'
             }
         }
-    }.writeTo("$buildDir/pom.xml")
+        scm {
+            url 'https://github.com/jvoegele/gradle-android-plugin'
+            connection 'scm:git://github.com/jvoegele/gradle-android-plugin.git'
+            developerConnection 'scm:git@github.com:jvoegele/gradle-android-plugin.git'
+        }
+        developers {
+            developer {
+                id 'jvoegele'
+                name 'Jason Voegele'
+                email 'jason.voegele@gmail.com'
+            }
+            developer {
+                id 'kaeppler'
+                name 'Matthias Käppler'
+                email 'm.kaeppler@googlemail.com'
+            }
+            developer {
+                id 'think01'
+                name 'Fabio Da Soghe'
+                email 'fabiodasoghe@gmail.com'
+            }
+            developer {
+                id 'Ladicek'
+                name 'Ladislav Thon'
+                email 'ladicek@gmail.com'
+            }
+            developer {
+                id 'ealden'
+                name 'Ealden Esto E. Escanan'
+                email 'ealden@gmail.com'
+            }
+            developer {
+                id 'erdi'
+                name 'Marcin Erdmann'
+                email 'erdi84@gmail.com'
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ uploadArchives {
         //configuration = configurations.sshDeploy
         //repository(url: "scp://jvoegele@chilco.textdrive.com/web/public/maven2")
         repository(url: "file:///tmp/maven2")
+        pom.artifactId = 'gradle-android-plugin'
     }
 }
 
@@ -115,7 +116,7 @@ task generatePom << {
     pom {
         project {
             groupId project.name
-            artifactId 'android-plugin'
+            artifactId 'gradle-android-plugin'
             version project.version
             packaging 'jar'
             name 'Gradle Android Plugin'

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,21 @@ clean << {
     ant.delete dir: pluginCacheDir
 }
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '1.0-milestone-6'
 }

--- a/src/integTest/groovy/com/jvoegele/gradle/android/AbstractIntegrationTest.groovy
+++ b/src/integTest/groovy/com/jvoegele/gradle/android/AbstractIntegrationTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.android
 
 import org.gradle.testfixtures.ProjectBuilder

--- a/src/integTest/groovy/com/jvoegele/gradle/android/HelloProjectTest.groovy
+++ b/src/integTest/groovy/com/jvoegele/gradle/android/HelloProjectTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.android
 
 import org.junit.Test

--- a/src/integTest/groovy/com/jvoegele/gradle/android/RandomProjectTest.groovy
+++ b/src/integTest/groovy/com/jvoegele/gradle/android/RandomProjectTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.android
 
 import org.junit.Test

--- a/src/integTest/groovy/com/jvoegele/gradle/android/support/MyBuildListener.groovy
+++ b/src/integTest/groovy/com/jvoegele/gradle/android/support/MyBuildListener.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.android.support
 
 import org.gradle.BuildAdapter

--- a/src/integTest/groovy/com/jvoegele/gradle/android/support/SignVerifier.groovy
+++ b/src/integTest/groovy/com/jvoegele/gradle/android/support/SignVerifier.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.android.support
 
 import java.security.cert.X509Certificate

--- a/src/integTest/groovy/com/jvoegele/gradle/android/support/TestArchive.groovy
+++ b/src/integTest/groovy/com/jvoegele/gradle/android/support/TestArchive.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.android.support
 
 import java.util.jar.JarFile

--- a/src/integTest/groovy/com/jvoegele/gradle/android/support/TestProject.groovy
+++ b/src/integTest/groovy/com/jvoegele/gradle/android/support/TestProject.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.android.support
 
 import org.gradle.GradleLauncher

--- a/src/integTest/groovy/com/jvoegele/gradle/android/support/ZipAlignVerifier.groovy
+++ b/src/integTest/groovy/com/jvoegele/gradle/android/support/ZipAlignVerifier.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.android.support
 
 import org.gradle.os.OperatingSystem

--- a/src/main/groovy/com/jvoegele/gradle/enhancements/EclipseEnhancement.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/enhancements/EclipseEnhancement.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.enhancements
 
 import org.gradle.api.Project 

--- a/src/main/groovy/com/jvoegele/gradle/enhancements/GradlePluginEnhancement.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/enhancements/GradlePluginEnhancement.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.enhancements
 
 import org.gradle.api.Project;

--- a/src/main/groovy/com/jvoegele/gradle/enhancements/JavadocEnhancement.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/enhancements/JavadocEnhancement.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.enhancements
 
 import org.gradle.api.Project 

--- a/src/main/groovy/com/jvoegele/gradle/enhancements/ScalaEnhancement.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/enhancements/ScalaEnhancement.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.enhancements
 
 import org.gradle.api.Project

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AbstractAndroidSetup.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AbstractAndroidSetup.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.plugins.android
 
 abstract class AbstractAndroidSetup implements AndroidSetup {

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPlugin.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.plugins.android
 
 import org.gradle.api.GradleException

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPluginConvention.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidPluginConvention.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.plugins.android;
 
 import org.gradle.api.Project 

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.plugins.android
 
 interface AndroidSetup {

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetupFactory.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetupFactory.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.plugins.android
 
 class AndroidSetupFactory {

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup_r13.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup_r13.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.plugins.android
 
 class AndroidSetup_r13 extends AbstractAndroidSetup {

--- a/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup_r14.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/plugins/android/AndroidSetup_r14.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.plugins.android
 
 class AndroidSetup_r14 extends AbstractAndroidSetup {

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AaptExecTask_r14.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AaptExecTask_r14.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 class AaptExecTask_r14 extends AndroidAntTask {

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AaptExecTask_r7.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AaptExecTask_r7.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 class AaptExecTask_r7 extends AndroidAntTask {

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AaptExecTask_r8.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AaptExecTask_r8.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 class AaptExecTask_r8 extends AndroidAntTask {

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AdbExec.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AdbExec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 import org.apache.tools.ant.util.TeeOutputStream

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidAntTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidAntTask.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 import com.jvoegele.gradle.plugins.android.AndroidPluginConvention 

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidPackageTask.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 import org.gradle.api.internal.ConventionTask

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSdkToolsFactory.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSdkToolsFactory.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 /**

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSignAndAlignTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSignAndAlignTask.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 import com.jvoegele.gradle.plugins.android.AndroidPluginConvention

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r14.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r14.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 class ApkBuilderTask_r14 extends AndroidAntTask {

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r6.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r6.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 class ApkBuilderTask_r6 extends AndroidAntTask {

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r7.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r7.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 import java.util.Map;

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r8.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r8.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 class ApkBuilderTask_r8 extends AndroidAntTask {

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/EmulatorTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/EmulatorTask.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android
 
 import org.gradle.api.DefaultTask

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ProGuard.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ProGuard.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android;
 
 import java.io.File;

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ProcessAndroidResources.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ProcessAndroidResources.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android;
 
 import groovy.lang.MetaClass

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/exceptions/AdbErrorException.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/exceptions/AdbErrorException.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android.exceptions
 
 import org.gradle.api.GradleException

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/exceptions/InstrumentationTestsFailedException.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/exceptions/InstrumentationTestsFailedException.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android.exceptions;
 
 class InstrumentationTestsFailedException extends AdbErrorException {

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/instrumentation/InstrumentationTestsTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/instrumentation/InstrumentationTestsTask.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android.instrumentation
 
 import com.jvoegele.gradle.plugins.android.AndroidPlugin;

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/instrumentation/TestRunnersConfig.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/instrumentation/TestRunnersConfig.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jvoegele.gradle.tasks.android.instrumentation
 
 /**


### PR DESCRIPTION
This pull request includes all changes necessary to meet the requirements of Sonatype, so we can have gradle-android-plugin available in Maven Central.

The list of requirements is at: https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide#SonatypeOSSMavenRepositoryUsageGuide-3.CreateaJIRAticket
