### PR TITLE
Add integration test assertions for debuggable flag

### DIFF
--- a/src/integTest/groovy/com/jvoegele/gradle/android/support/TestArchive.groovy
+++ b/src/integTest/groovy/com/jvoegele/gradle/android/support/TestArchive.groovy
@@ -17,8 +17,11 @@
 package com.jvoegele.gradle.android.support
 
 import java.util.jar.JarFile
+import org.gradle.internal.os.OperatingSystem
 
+import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
 
 class TestArchive {
   def project
@@ -35,5 +38,35 @@ class TestArchive {
 
   def assertSigned(distinguishedName) {
     new SignVerifier(archive: archive).verify(distinguishedName)
+  }
+
+  def assertDebuggable() {
+    assertTrue "The archive ${archive} must have the android:debuggable attribute set", isDebuggable()
+  }
+
+  def assertNotDebuggable() {
+    assertFalse "The archive ${archive} must not have the android:debuggable attribute set", isDebuggable()
+  }
+
+  def isDebuggable() {
+    def androidTools = new File(System.getenv("ANDROID_HOME"), "platform-tools")
+    def aapt = new File(androidTools, "aapt${OperatingSystem.current().isWindows() ? '.exe' : ''}")
+    def debuggable = false
+
+    new ByteArrayOutputStream().withStream { os ->
+      project.exec {
+        executable aapt.canonicalPath
+        args 'list', '-v', '-a', archive
+        standardOutput = os
+        ignoreExitValue = true
+      }
+      os.toString().eachLine {
+        if (it.contains("A: android:debuggable") && it.contains("=(type 0x12)0xffffffff")) {
+          debuggable = true
+        }
+      }
+    }
+    
+    debuggable
   }
 }


### PR DESCRIPTION
This patch adds assertions in the HelloWorld test for the debuggable flag being set (or not set) in the resulting APK.  The assertions are skipped on aapt versions less than 8 (where aapt does not support this feature).
