### PR TITLE
Improve default Proguard rules

### DIFF
--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r14.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r14.groovy
@@ -44,6 +44,7 @@ class ApkBuilderTask_r14 extends AndroidAntTask {
       }
 
       nativefolder(path: androidConvention.nativeLibsDir)
+      project.configurations.runtime.each { jarfile(path: it) }
     }
   }
 }

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r7.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r7.groovy
@@ -44,6 +44,7 @@ class ApkBuilderTask_r7 extends AndroidAntTask {
 		  sourcefolder(path: project.sourceSets.main.output.resourcesDir)
 	  }
       nativefolder(path: androidConvention.nativeLibsDir)
+      project.configurations.runtime.each { jarfile(path: it) }
     }
 /*
             <apkbuilder>

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r8.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ApkBuilderTask_r8.groovy
@@ -42,6 +42,7 @@ class ApkBuilderTask_r8 extends AndroidAntTask {
 		  sourcefolder(path: project.sourceSets.main.output.resourcesDir)
 	  }
       nativefolder(path: androidConvention.nativeLibsDir)
+      project.configurations.runtime.each { jarfile(path: it) }
     }
 /*
             <apkbuilder>

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ProGuard.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ProGuard.groovy
@@ -112,6 +112,9 @@ class ProGuard extends DefaultTask {
           method(access: 'public static', type: '**[]', name: 'values', parameters: '')
           method(access: 'public static', type: '**', name: 'valueOf', parameters: 'java.lang.String')
         }
+        keepclassmembers('extends': 'android.app.Activity') {
+          method(access: 'public', type: 'void', name: '*', parameters: 'android.view.View')
+        }
         keep('implements': 'android.os.Parcelable') {
           field(access: 'public static final', type: 'android.os.Parcelable$Creator')
         }


### PR DESCRIPTION
Have updated default Proguard rules to keep activity methods that are valid handlers for click events. This rule is in the default Android SDK Proguard config.
