### PR TITLE
Fixes Issue  #80 

### DIFF
--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSignAndAlignTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSignAndAlignTask.groovy
@@ -42,7 +42,7 @@ class AndroidSignAndAlignTask extends DefaultTask {
       throw new GradleException("Keystore file ${keystore} not found")
 
     def args = [JavaEnvUtils.getJdkExecutable('jarsigner'),
-                verbose?'-verbose':'',
+                '-verbose',
                 '-sigalg', 'MD5withRSA',
                 '-digestalg', 'SHA1',
                 '-keystore', keystore,


### PR DESCRIPTION
When `androidSignAndAlign` is called, the application is expecting data back from jarsign. I have given the option to do verbose output. This should fix the issue aswell as give useful debugging info for people who enable it.
