### PR TITLE
Fix for issue #77

### DIFF
--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ProcessAndroidResources.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ProcessAndroidResources.groovy
@@ -24,6 +24,8 @@ import org.gradle.api.tasks.TaskAction
 import com.jvoegele.gradle.plugins.android.AndroidPluginConvention
 import groovy.io.FileType
 
+import java.util.regex.Matcher
+
 class ProcessAndroidResources extends DefaultTask {
   boolean verbose
 

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/ProcessAndroidResources.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/ProcessAndroidResources.groovy
@@ -97,7 +97,7 @@ class ProcessAndroidResources extends DefaultTask {
     def packageDir = getPackageDir()
 
     // Replace all path separators to a dot and strip out the first dot.
-    def packageDeclaration = packageDir.replaceAll( File.separator, '.' )
+    def packageDeclaration = packageDir.replaceAll( Matcher.quoteReplacement(File.separator), '.' )
     packageDeclaration = packageDeclaration.substring( 1, packageDeclaration.length() )
 
     def isDebug = project.version.endsWith("-SNAPSHOT")


### PR DESCRIPTION
This is my first time doing this so let me know if I did something wrong or over-stepped my bounds. This is in regard to the following issue:

https://github.com/jvoegele/gradle-android-plugin/issues/77

On Windows, the file path separator is '\', but this has special meaning in constructing java regexes. This is a fix recommended by user [jvdvTechno](https://github.com/jvdvTechno). 

Commit message detail: 
Use the quoteReplacement method to return  literal character
reperesentation of the file separator for any operating system.
