### PR TITLE
Fix creation of debug keystore to fix issue #84

### DIFF
--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSignAndAlignTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSignAndAlignTask.groovy
@@ -139,7 +139,9 @@ class AndroidSignAndAlignTask extends DefaultTask {
             keypass: 'android',
             validity: 10 * 365,
             storetype: 'JKS',
-            dname: 'CN=Android Debug,O=Android,C=US')
+            dname: 'CN=Android Debug,O=Android,C=US',
+            sigalg: sigalg != null ? sigalg : 'MD5withRSA',
+            keyalg: digestalg != null ? digestalg : 'SHA1')
       }
 
       return debugKeystore.absolutePath

--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSignAndAlignTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSignAndAlignTask.groovy
@@ -30,6 +30,7 @@ class AndroidSignAndAlignTask extends DefaultTask {
   @Optional @Input String keyAliasPassword
   @Optional @Input String sigalg
   @Optional @Input String digestalg
+  @Optional @Input String keyalg
   boolean verbose
 
   private File customUnsingedArchivePath
@@ -141,7 +142,7 @@ class AndroidSignAndAlignTask extends DefaultTask {
             storetype: 'JKS',
             dname: 'CN=Android Debug,O=Android,C=US',
             sigalg: sigalg != null ? sigalg : 'MD5withRSA',
-            keyalg: digestalg != null ? digestalg : 'SHA1')
+            keyalg: keyalg != null ? keyalg : 'RSA')
       }
 
       return debugKeystore.absolutePath


### PR DESCRIPTION
The generation of the debug keystore was not implicitly setting the desired keyalg and so the system uses it's own default - which causes issues for some people's setup because the keyalg is related to the sigalg, and the sigalg is defaulted in the code - but not the keyalg so if they are at odds with one another you get errors as seen in issue #84, this fixes that and also makes it configurable - though obviously it only applies when not using your own keystore.
