### PR TITLE
Create .android dir in user's home directory if it doesn't already exist...

### DIFF
--- a/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSignAndAlignTask.groovy
+++ b/src/main/groovy/com/jvoegele/gradle/tasks/android/AndroidSignAndAlignTask.groovy
@@ -128,7 +128,15 @@ class AndroidSignAndAlignTask extends DefaultTask {
   }
 
   private String retrieveDebugKeystore() {
-      File debugKeystore = new File(System.getProperty('user.home'), '.android/debug.keystore')
+      File usersAndroidDir = new File(System.getProperty('user.home'), '.android')
+      if(!usersAndroidDir.exists()){
+        def result = usersAndroidDir.mkdirs()
+        if(!result){
+          throw new GradleException("Failed creating " + usersAndroidDir)
+        }
+      }
+
+      File debugKeystore = new File(usersAndroidDir, 'debug.keystore')
 
       if (!debugKeystore.exists()) {
         logger.info('Creating a new debug key...')


### PR DESCRIPTION
.... Otherwise keytool flips out with a FileNotFound error as it does not attempt to create missing directories.

Cheers,
Si
